### PR TITLE
86b12k7gc [FE] Adding missing fields within Admin Payment Page

### DIFF
--- a/src/pages/Admin/Payments/PaymentTable/PaymentTable.js
+++ b/src/pages/Admin/Payments/PaymentTable/PaymentTable.js
@@ -1,17 +1,53 @@
 import { DataGrid } from '@mui/x-data-grid';
+import { getStatus } from '../../../../utils/paymentUtils';
+import './PaymentTable.scss';
 
 const columns = [
   { field: 'paymentId', headerName: 'ID', width: 180 },
   { field: 'externalReference', headerName: 'Referencia de pago', width: 280 },
   { field: 'description', headerName: 'Clase', width: 110 },
+  { field: 'title', headerName: 'Nivel-Horario', width: 110 },
   {
     field: 'unitPrice',
     headerName: 'Pago',
     type: 'number',
     width: 60,
   },
-  { field: 'status', headerName: 'Estado', width: 130 },
-  { field: 'studentId', headerName: 'Estudiante', type: 'number', width: 90 },
+  {
+    field: 'status',
+    headerName: 'Estado',
+    width: 130,
+    renderCell: (value) => {
+      const statusObj = value?.value ? getStatus(value.value) : { name: 'No disponible' };
+      return (
+        <span className="space dot">
+          {statusObj.name}
+          {statusObj?.icon}
+        </span>
+      );
+    },
+  },
+  {
+    field: 'createdAt',
+    headerName: 'Fecha de pago',
+    type: 'dateTime',
+    width: 150,
+    valueGetter: (value) => value && new Date(value),
+  },
+  {
+    field: 'fullName',
+    headerName: 'Pagado por',
+    type: 'number',
+    width: 110,
+    valueGetter: (value, row) =>
+      `${row.user.name || ''} ${row.user.surname || ''}`,
+  },
+  {
+    field: 'user.email',
+    headerName: 'Email',
+    width: 110,
+    valueGetter: (value, row) => `${row.user.email || ''}`,
+  },
 ];
 
 export default function PaymentTable({ rows }) {

--- a/src/pages/Admin/Payments/PaymentTable/PaymentTable.scss
+++ b/src/pages/Admin/Payments/PaymentTable/PaymentTable.scss
@@ -1,0 +1,22 @@
+@import '../../../../assets/styles/variables.scss';
+
+.space {
+  &.dot {
+    display: flex;
+    flex-direction: row;
+    align-items: center;
+    justify-content: center;
+    .yellow {
+      color: rgb(255, 225, 0);
+    }
+    .green {
+      color: rgb(42, 159, 42);
+    }
+    .red {
+      color: rgb(163, 33, 33);
+    }
+    .gray {
+      color: $light-gray;
+    }
+  }
+}

--- a/src/pages/Admin/Payments/Payments.js
+++ b/src/pages/Admin/Payments/Payments.js
@@ -16,7 +16,7 @@ const Payments = () => {
     useAdminRequest();
 
   useEffectOnce(() => {
-    dispatch(changeContent(getMenuOption('marketing')));
+    dispatch(changeContent(getMenuOption('payment')));
     setGetRequest({
       type: 'get-payments',
     });


### PR DESCRIPTION
As an admin user I should be able to see the name, lastname and email for the user linked to payment as well as the class detail (schedule and class level) and the payment date.

![image](https://github.com/IdiomaSpot/idioma-spot-ui/assets/93946659/9efd6de8-77ac-42ef-97b8-cc70472005ff)
